### PR TITLE
Pop - remove bubble when entering a matching word

### DIFF
--- a/src/components/common/Keyboard.tsx
+++ b/src/components/common/Keyboard.tsx
@@ -116,13 +116,14 @@ const LetterEng = styled(Letter)`
   }
 `;
 
-const pressed = { backgroundColor: "#FF7D7D", color: "black", border: "1px solid black" };
+// TODO: see if there's another way to implement this
+// const pressed = { backgroundColor: "#FF7D7D", color: "black", border: "1px solid black" };
 
-function KeyboardRow(props: ({ rowLetters: Array<KeyType>, pressedKey: string })): JSX.Element {
+function KeyboardRow(props: ({ rowLetters: Array<KeyType>, })): JSX.Element {
   return (
     <Row numOfEl={props.rowLetters.length}>
       {props.rowLetters.map((key, index) => (
-        <Key key={`${key}${index}`} style={props.pressedKey.localeCompare(key.eng) === 0 ? pressed : {}}>
+        <Key key={`${key}${index}`} >
           <Contents>
 
             <Top>
@@ -152,18 +153,14 @@ interface KeyboardProps extends StyledProps {
 }
 function Keyboard(props: KeyboardProps) {
   const [word, setWord] = useState("");
-  const [pressedKey, setPressedKey] = useState("");
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>): void {
-    setPressedKey(e.target.value.substr(-1));
     setWord(e.target.value);
-    setTimeout(() => { setPressedKey("") }, 100);
   }
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>): void {
     e.preventDefault();
     props.onSubmit(word);
-    setPressedKey("");
     setWord("");
   }
 
@@ -177,9 +174,9 @@ function Keyboard(props: KeyboardProps) {
           value={word}
           autoFocus />
       </form>
-      <KeyboardRow rowLetters={topRow} pressedKey={pressedKey} />
-      <KeyboardRow rowLetters={midRow} pressedKey={pressedKey} />
-      <KeyboardRow rowLetters={botRow} pressedKey={pressedKey} />
+      <KeyboardRow rowLetters={topRow} />
+      <KeyboardRow rowLetters={midRow} />
+      <KeyboardRow rowLetters={botRow} />
     </Container>
   );
 }

--- a/src/components/common/Keyboard.tsx
+++ b/src/components/common/Keyboard.tsx
@@ -1,14 +1,9 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
-import { Fonts, Sizes, StyledProps } from "../../helpers";
+import { Fonts, KeyType, Sizes, StyledProps } from "../../helpers";
 
-interface Key {
-  eng: string;
-  shift: string;
-  kor: string;
-}
-const topRow: Array<Key> = [
+const topRow: Array<KeyType> = [
   { eng: "q", shift: "ㅃ", kor: "ㅂ" },
   { eng: "w", shift: "ㅉ", kor: "ㅈ" },
   { eng: "e", shift: "ㄸ", kor: "ㄷ" },
@@ -20,7 +15,7 @@ const topRow: Array<Key> = [
   { eng: "o", shift: "ㅒ", kor: "ㅐ" },
   { eng: "p", shift: "ㅖ", kor: "ㅔ" },
 ];
-const midRow: Array<Key> = [
+const midRow: Array<KeyType> = [
   { eng: "a", shift: "", kor: "ㅁ" },
   { eng: "s", shift: "", kor: "ㄴ" },
   { eng: "d", shift: "", kor: "ㅇ" },
@@ -31,7 +26,7 @@ const midRow: Array<Key> = [
   { eng: "k", shift: "", kor: "ㅏ" },
   { eng: "l", shift: "", kor: "ㅣ" },
 ];
-const botRow: Array<Key> = [
+const botRow: Array<KeyType> = [
   { eng: "z", shift: "", kor: "ㅋ" },
   { eng: "x", shift: "", kor: "ㅌ" },
   { eng: "c", shift: "", kor: "ㅊ" },
@@ -121,45 +116,9 @@ const LetterEng = styled(Letter)`
   }
 `;
 
-// https://stackoverflow.com/questions/29069639/listen-to-keypress-for-document-in-reactjs
-function useEventListener(eventName: string, handler: (e: KeyboardEvent) => void, element = window) {
-  // Create a ref that stores handler
-  const savedHandler = useRef();
-
-  // Update ref.current value if handler changes.
-  // This allows our effect below to always get latest handler ...
-  // ... without us needing to pass it in effect deps array ...
-  // ... and potentially cause effect to re-run every render.
-  useEffect(() => {
-    // @ts-ignore
-    savedHandler.current = handler;
-  }, [handler]);
-
-  useEffect(
-    () => {
-      // Make sure element supports addEventListener
-      const isSupported = element && element.addEventListener;
-      if (!isSupported) return;
-
-      // Create event listener that calls handler function stored in ref
-      // @ts-ignore
-      const eventListener = event => savedHandler.current(event);
-
-      // Add event listener
-      element.addEventListener(eventName, eventListener);
-
-      // Remove event listener on cleanup
-      return () => {
-        element.removeEventListener(eventName, eventListener);
-      };
-    },
-    [eventName, element] // Re-run if eventName or element changes
-  );
-};
-
 const pressed = { backgroundColor: "#FF7D7D", color: "black", border: "1px solid black" };
 
-function KeyboardRow(props: ({ rowLetters: Array<Key>, pressedKey: string })): JSX.Element {
+function KeyboardRow(props: ({ rowLetters: Array<KeyType>, pressedKey: string })): JSX.Element {
   return (
     <Row numOfEl={props.rowLetters.length}>
       {props.rowLetters.map((key, index) => (
@@ -189,24 +148,34 @@ function KeyboardRow(props: ({ rowLetters: Array<Key>, pressedKey: string })): J
 }
 
 interface KeyboardProps extends StyledProps {
-  onKeyPress: (pressedKey: string) => void;
+  onKeyPress: (key: string) => void;
 }
 function Keyboard(props: KeyboardProps) {
-  const [pressedKey, setKey] = useState("");
+  const [word, setWord] = useState("");
+  const [pressedKey, setPressedKey] = useState("");
 
-  function handleDown(e: KeyboardEvent) {
-    setKey(e.key);
-    props.onKeyPress(e.key);
-
-    setTimeout(() => {
-      setKey("");
-    }, 100);
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>): void {
+    setPressedKey(e.target.value.substr(-1));
+    setWord(e.target.value);
+    setTimeout(() => { setPressedKey("") }, 100);
   }
 
-  useEventListener("keydown", handleDown);
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>): void {
+    e.preventDefault();
+    props.onKeyPress(word);
+    setPressedKey("");
+    setWord("");
+  }
 
   return (
     <Container className={props.className}>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          onChange={handleChange}
+          value={word}
+          autoFocus />
+      </form>
       <KeyboardRow rowLetters={topRow} pressedKey={pressedKey} />
       <KeyboardRow rowLetters={midRow} pressedKey={pressedKey} />
       <KeyboardRow rowLetters={botRow} pressedKey={pressedKey} />

--- a/src/components/common/Keyboard.tsx
+++ b/src/components/common/Keyboard.tsx
@@ -148,7 +148,7 @@ function KeyboardRow(props: ({ rowLetters: Array<KeyType>, pressedKey: string })
 }
 
 interface KeyboardProps extends StyledProps {
-  onKeyPress: (key: string) => void;
+  onSubmit: (key: string) => void;
 }
 function Keyboard(props: KeyboardProps) {
   const [word, setWord] = useState("");
@@ -162,11 +162,12 @@ function Keyboard(props: KeyboardProps) {
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>): void {
     e.preventDefault();
-    props.onKeyPress(word);
+    props.onSubmit(word);
     setPressedKey("");
     setWord("");
   }
 
+  // TODO: update when I update the design for the form input
   return (
     <Container className={props.className}>
       <form onSubmit={handleSubmit}>

--- a/src/components/game/Display.tsx
+++ b/src/components/game/Display.tsx
@@ -61,11 +61,11 @@ const Ground = styled.img`
 interface DisplayProps {
   game: Game;
   className?: string;
-  objects: Array<JSX.Element>;
+  children: Array<JSX.Element>;
 }
 
 function Display(props: DisplayProps) {
-  const { className, objects } = props;
+  const { className, children } = props;
   const game = props.game.toLowerCase();
 
   return (
@@ -106,7 +106,7 @@ function Display(props: DisplayProps) {
         <path fillRule="evenodd" clipRule="evenodd" d="M37.998 105H38L44.3084 111.25L50.5 105.116L56.6916 111.25L62.5606 105.435C67.0982 109.102 70 114.712 70 121C70 132.046 61.0457 141 50 141C38.9543 141 30 132.046 30 121C30 114.458 33.1414 108.649 37.998 105Z" fill="white" />
       </Ryan>
 
-      {objects}
+      {children}
 
     </Container >
   );

--- a/src/components/game/helpers.ts
+++ b/src/components/game/helpers.ts
@@ -1,3 +1,4 @@
+import { Game } from "../../helpers";
 import wordJson from "./vocab.json";
 
 export interface Word {
@@ -5,7 +6,58 @@ export interface Word {
   word: string;
   definition: string;
 }
+interface WordManagerTest {
+  getUsedWords: () => Array<number>;
+}
+export interface WordManager {
+  select: () => Word;
+  reset: () => void;
+  Test: WordManagerTest;
+}
 
 const WORDS: Array<Word> = JSON.parse(JSON.stringify(wordJson));
 
-export { WORDS };
+
+function isNotAGame(param: string): boolean {
+  const type = param.toLowerCase();
+  return type.localeCompare("run") !== 0
+    && type.localeCompare("pop") !== 0
+    && type.localeCompare("jump") !== 0;
+}
+
+function gameTypeChanged(previous: Game, current: Game): boolean {
+  return previous.localeCompare(current) !== 0;
+}
+
+function wordManager(): WordManager {
+  // just the index really
+  let usedWords: Array<number> = [];
+
+  function select(): Word {
+    const index = Math.floor(Math.random() * WORDS.length);
+    const wasUsed = usedWords.find(i => i === index);
+
+    if (wasUsed) {
+      return select();
+    }
+
+    usedWords = [...usedWords, index];
+    return WORDS[index];
+  }
+
+  function reset(): void {
+    usedWords = [];
+  }
+
+  return {
+    select,
+    reset,
+    Test: {
+      getUsedWords: function () {
+        return [...usedWords];
+      }
+    }
+  }
+}
+
+export { WORDS, gameTypeChanged, isNotAGame, wordManager };

--- a/src/components/game/index.tsx
+++ b/src/components/game/index.tsx
@@ -5,8 +5,8 @@ import styled from "styled-components";
 import { Game, } from "../../helpers";
 import { Keyboard, MenuBtn, Page404 } from "../common";
 import Display from "./Display";
+import { gameTypeChanged, isNotAGame, wordManager } from "./helpers";
 import manageGameObjects from "./manager";
-import { WORDS, Word } from "./helpers";
 
 const Container = styled.div`
   display: flex;
@@ -29,40 +29,6 @@ const MenuBtnFloating = styled(MenuBtn)`
   }
 `;
 
-function isNotAGame(param: string): boolean {
-  const type = param.toLowerCase();
-  return type.localeCompare("run") !== 0
-    && type.localeCompare("pop") !== 0
-    && type.localeCompare("jump") !== 0;
-}
-
-function gameTypeChanged(previous: Game, current: Game): boolean {
-  return previous.localeCompare(current) !== 0;
-}
-
-function wordManager() {
-  let usedWords: Array<number> = [];
-
-  function select(): Word {
-    const index = Math.floor(Math.random() * WORDS.length);
-    const wasUsed = usedWords.find(i => i === index);
-
-    if (wasUsed) {
-      return select();
-    }
-
-    return WORDS[index];
-  }
-
-  function reset(): void {
-    usedWords = [];
-  }
-
-  return {
-    select,
-    reset,
-  }
-}
 
 interface Params {
   type: Game;
@@ -139,7 +105,7 @@ function Controller() {
   //   toggleGameOver(true);
   // }
 
-  function handleKeyPress(enteredWord: string): void {
+  function handleSubmit(enteredWord: string): void {
     const word = words.find(w => w.word.localeCompare(enteredWord) === 0);
     if (word) {
       switch (game) {
@@ -165,7 +131,7 @@ function Controller() {
       <Display game={params.type}>
         {gameObjects.current}
       </Display>
-      <Keyboard onKeyPress={handleKeyPress} />
+      <Keyboard onSubmit={handleSubmit} />
 
       <MenuBtnFloating />
     </Container>

--- a/src/components/game/manager.tsx
+++ b/src/components/game/manager.tsx
@@ -28,7 +28,6 @@ interface Test {
 }
 export interface Manager {
   renderBubble: (word: Word) => JSX.Element;
-  popBubble: () => void;
   renderCon: (word: Word) => JSX.Element;
   renderPlatform: (word: Word) => JSX.Element;
   jumpToPlatform: (node: SVGElement) => void;
@@ -209,9 +208,6 @@ function manageGameObjects(): Manager {
       }
 
       return renderBubble(word, x);
-    },
-    popBubble: function (): void {
-      // remove bubble from display
     },
     renderCon: function (word: Word) {
       // TODO

--- a/src/components/game/manager.tsx
+++ b/src/components/game/manager.tsx
@@ -9,9 +9,6 @@ interface Coordinates {
   x: number;
   y: number;
 }
-interface BubbleProps extends Coordinates {
-  rate: number;
-}
 export interface BubblesX {
   available: Array<number>;
   recent: [number?, number?, number?];
@@ -28,6 +25,7 @@ interface Test {
 }
 export interface Manager {
   renderBubble: (word: Word) => JSX.Element;
+  popBubble: (word: Word) => void;
   renderCon: (word: Word) => JSX.Element;
   renderPlatform: (word: Word) => JSX.Element;
   jumpToPlatform: (node: SVGElement) => void;
@@ -35,7 +33,7 @@ export interface Manager {
   Test: Test;
 }
 
-function fallDown(props: BubbleProps) {
+function fallDown(props: Coordinates) {
   const waver = window.innerWidth < 720 ? [10, 20, 30] : [30, 40, 50];
   const side = ["left", "right"][Math.round(Math.random())];
   const operation = ["+", "-"][Math.round(Math.random())];
@@ -72,7 +70,7 @@ const Sign = styled.span`
   color: white;
   font-size: ${Sizes.variable.font.small};
 `;
-const Bubble = styled.div<BubbleProps>`
+const Bubble = styled.div<Coordinates>`
   position: absolute;
   top: ${props => props.y}px;
   left: ${props => props.x}px;
@@ -84,7 +82,7 @@ const Bubble = styled.div<BubbleProps>`
   justify-content: center;
   align-items: center;
   animation-name: ${fallDown};
-  animation-duration: ${props => props.rate * 3000}ms;
+  animation-duration: 12000ms;
   animation-timing-function: ease-in;
   animation-fill-mode: forwards;
 `;
@@ -121,7 +119,6 @@ function renderBubble(vocab: Word, xValue: number): JSX.Element {
       id={vocab.id} key={vocab.id}
       x={xValue}
       y={window.innerWidth < 720 ? -49 : -99}
-      rate={1}
     >
       <BubbleText>{vocab.word}</BubbleText>
     </Bubble>
@@ -208,6 +205,13 @@ function manageGameObjects(): Manager {
       }
 
       return renderBubble(word, x);
+    },
+    popBubble: function (word: Word): void {
+      const element = document.getElementById(word.id);
+      if (element) {
+        element.style.transform = "scale(0)";
+        element.style.transition = "transform 150ms ease";
+      }
     },
     renderCon: function (word: Word) {
       // TODO

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -29,38 +29,9 @@ const Sizes = {
   },
 }
 
-const ALL_KEYS = [
-  { eng: "q", shift: "ㅃ", kor: "ㅂ" },
-  { eng: "w", shift: "ㅉ", kor: "ㅈ" },
-  { eng: "e", shift: "ㄸ", kor: "ㄷ" },
-  { eng: "r", shift: "ㄲ", kor: "ㄱ" },
-  { eng: "t", shift: "ㅆ", kor: "ㅅ" },
-  { eng: "y", shift: "", kor: "ㅛ" },
-  { eng: "u", shift: "", kor: "ㅕ" },
-  { eng: "i", shift: "", kor: "ㅑ" },
-  { eng: "o", shift: "ㅒ", kor: "ㅐ" },
-  { eng: "p", shift: "ㅖ", kor: "ㅔ" },
-  { eng: "a", shift: "", kor: "ㅁ" },
-  { eng: "s", shift: "", kor: "ㄴ" },
-  { eng: "d", shift: "", kor: "ㅇ" },
-  { eng: "f", shift: "", kor: "ㄹ" },
-  { eng: "g", shift: "", kor: "ㅎ" },
-  { eng: "h", shift: "", kor: "ㅗ" },
-  { eng: "j", shift: "", kor: "ㅓ" },
-  { eng: "k", shift: "", kor: "ㅏ" },
-  { eng: "l", shift: "", kor: "ㅣ" },
-  { eng: "z", shift: "", kor: "ㅋ" },
-  { eng: "x", shift: "", kor: "ㅌ" },
-  { eng: "c", shift: "", kor: "ㅊ" },
-  { eng: "v", shift: "", kor: "ㅍ" },
-  { eng: "b", shift: "", kor: "ㅠ" },
-  { eng: "n", shift: "", kor: "ㅜ" },
-  { eng: "m", shift: "", kor: "ㅡ" },
-];
-
 const fadeIn = keyframes`
   from { opacity: 0; }
   to { opacity: 1; }
 `;
 
-export { ALL_KEYS, Fonts, Sizes, fadeIn };
+export { Fonts, Sizes, fadeIn };

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -6,6 +6,12 @@ export interface StyledProps {
   className?: string;
 }
 
+export interface KeyType {
+  eng: string;
+  shift: string;
+  kor: string;
+}
+
 const Fonts = {
   playfair: "'Playfair Display', serif",
   nanum: "'Nanum Pen Script', cursive",
@@ -23,9 +29,38 @@ const Sizes = {
   },
 }
 
+const ALL_KEYS = [
+  { eng: "q", shift: "ㅃ", kor: "ㅂ" },
+  { eng: "w", shift: "ㅉ", kor: "ㅈ" },
+  { eng: "e", shift: "ㄸ", kor: "ㄷ" },
+  { eng: "r", shift: "ㄲ", kor: "ㄱ" },
+  { eng: "t", shift: "ㅆ", kor: "ㅅ" },
+  { eng: "y", shift: "", kor: "ㅛ" },
+  { eng: "u", shift: "", kor: "ㅕ" },
+  { eng: "i", shift: "", kor: "ㅑ" },
+  { eng: "o", shift: "ㅒ", kor: "ㅐ" },
+  { eng: "p", shift: "ㅖ", kor: "ㅔ" },
+  { eng: "a", shift: "", kor: "ㅁ" },
+  { eng: "s", shift: "", kor: "ㄴ" },
+  { eng: "d", shift: "", kor: "ㅇ" },
+  { eng: "f", shift: "", kor: "ㄹ" },
+  { eng: "g", shift: "", kor: "ㅎ" },
+  { eng: "h", shift: "", kor: "ㅗ" },
+  { eng: "j", shift: "", kor: "ㅓ" },
+  { eng: "k", shift: "", kor: "ㅏ" },
+  { eng: "l", shift: "", kor: "ㅣ" },
+  { eng: "z", shift: "", kor: "ㅋ" },
+  { eng: "x", shift: "", kor: "ㅌ" },
+  { eng: "c", shift: "", kor: "ㅊ" },
+  { eng: "v", shift: "", kor: "ㅍ" },
+  { eng: "b", shift: "", kor: "ㅠ" },
+  { eng: "n", shift: "", kor: "ㅜ" },
+  { eng: "m", shift: "", kor: "ㅡ" },
+];
+
 const fadeIn = keyframes`
   from { opacity: 0; }
   to { opacity: 1; }
 `;
 
-export { Fonts, Sizes, fadeIn };
+export { ALL_KEYS, Fonts, Sizes, fadeIn };

--- a/src/test/Game.test.tsx
+++ b/src/test/Game.test.tsx
@@ -1,0 +1,77 @@
+import { WordManager, gameTypeChanged, isNotAGame, wordManager } from "../components/game/helpers";
+
+describe("Game", () => {
+
+  describe("helpers", () => {
+    enum Game {
+      run = "run",
+      pop = "pop",
+      jump = "jump",
+    }
+
+    describe("gameTypeChanged()", () => {
+      it("returns TRUE when the game changed from 'run' to 'pop'", () => {
+        expect(gameTypeChanged(Game.run, Game.pop)).toBe(true);
+      });
+      it("returns TRUE when the game changed from 'pop' to 'run'", () => {
+        expect(gameTypeChanged(Game.pop, Game.run)).toBe(true);
+      });
+      it("returns TRUE when the game changed from 'pop' to 'jump'", () => {
+        expect(gameTypeChanged(Game.pop, Game.jump)).toBe(true);
+      });
+      it("returns TRUE when the game changed from 'run' to 'jump'", () => {
+        expect(gameTypeChanged(Game.run, Game.jump)).toBe(true);
+      });
+      it("returns TRUE when the game changed from 'jump' to 'run'", () => {
+        expect(gameTypeChanged(Game.jump, Game.run)).toBe(true);
+      });
+      it("returns TRUE when the game changed from 'jump' to 'pop'", () => {
+        expect(gameTypeChanged(Game.jump, Game.pop)).toBe(true);
+      });
+      it("returns FALSE when the game hasn't changed", () => {
+        expect(gameTypeChanged(Game.run, Game.run)).toBe(false);
+      });
+    });
+
+    describe("isNotAGame()", () => {
+      it("returns TRUE if anything other than 'run', 'pop', or 'jump'", () => {
+        expect(isNotAGame("poop")).toBe(true);
+        expect(isNotAGame("duh")).toBe(true);
+        expect(isNotAGame("bahhaha")).toBe(true);
+        expect(isNotAGame("123")).toBe(true);
+        expect(isNotAGame("...")).toBe(true);
+        expect(isNotAGame("   ")).toBe(true);
+        expect(isNotAGame("")).toBe(true);
+      });
+      it("returns FALSE if either 'run', 'pop', or 'jump'", () => {
+        expect(isNotAGame(Game.run)).toBe(false);
+        expect(isNotAGame(Game.pop)).toBe(false);
+        expect(isNotAGame(Game.jump)).toBe(false);
+      });
+    });
+
+    describe("wordManager()", () => {
+      let manager: WordManager;
+
+      beforeAll(() => {
+        manager = wordManager();
+      })
+
+      it("calling select() will choose a random word and keep track of it", () => {
+        const before = manager.Test.getUsedWords();
+        manager.select();
+        const after = manager.Test.getUsedWords();
+        expect(before.length).toBe(0);
+        expect(after.length).toBe(1);
+      });
+
+      it("calling reset() clears the record of all used words", () => {
+        const before = manager.Test.getUsedWords();
+        manager.reset();
+        const after = manager.Test.getUsedWords();
+        expect(before.length).toBe(1);
+        expect(after.length).toBe(0);
+      })
+    });
+  });
+});

--- a/src/test/Keyboard.test.tsx
+++ b/src/test/Keyboard.test.tsx
@@ -34,14 +34,16 @@ describe("<Keyboard/>", () => {
     }
   });
 
-  it("passes up the typed word when hitting 'Enter'", () => {
+  it("passes up the typed word when hitting 'Enter' and input value is cleared", () => {
     const input = container.querySelector("input");
     const form = container.querySelector("form");
     if (input && form) {
       input.value = "바보";
       ReactTestUtils.Simulate.change(input);
       ReactTestUtils.Simulate.submit(form);
+
       expect(onSubmit).toBeCalledWith("바보");
+      expect(input.value).toBe("");
     }
   });
 });

--- a/src/test/Keyboard.test.tsx
+++ b/src/test/Keyboard.test.tsx
@@ -9,36 +9,39 @@ import Keyboard from "../components/common/Keyboard";
 const noOp = () => { };
 
 describe("<Keyboard/>", () => {
+  let container: HTMLDivElement;
+  let onSubmit: (word: string) => void;
+
+  beforeAll(() => {
+    container = document.createElement("div");
+    onSubmit = jest.fn();
+    ReactDOM.render(<Keyboard onSubmit={onSubmit} />, container);
+  });
+
   it('renders correctly', () => {
     const tree = renderer
-      .create(<Keyboard onKeyPress={noOp} />)
+      .create(<Keyboard onSubmit={noOp} />)
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it("passes pressed key up to parent upon keydown event", () => {
-    interface EventListeners {
-      error?: EventListenerOrEventListenerObject;
-      keydown?: EventListenerOrEventListenerObject;
-      keyup?: EventListenerOrEventListenerObject;
+  it("doesn't pass up the typed word when typing", () => {
+    const input = container.querySelector("input");
+    if (input) {
+      input.value = "바보";
+      ReactTestUtils.Simulate.change(input);
+      expect(onSubmit).not.toBeCalled();
     }
-    type Event = "error" | "keydown" | "keyup";
-    const map: EventListeners = {};
-    window.addEventListener = jest.fn((event, cb) => {
-      map[(event as Event)] = cb;
-    });
-    const onKeyPress = jest.fn();
+  });
 
-    const container = document.createElement("div");
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<Keyboard onKeyPress={onKeyPress} />, container);
-    });
-    ReactTestUtils.act(() => {
-      if (map.keydown) {
-        // @ts-ignore
-        map.keydown({ key: "KeyA" })
-      }
-      expect(onKeyPress).toBeCalledWith("KeyA");
-    });
+  it("passes up the typed word when hitting 'Enter'", () => {
+    const input = container.querySelector("input");
+    const form = container.querySelector("form");
+    if (input && form) {
+      input.value = "바보";
+      ReactTestUtils.Simulate.change(input);
+      ReactTestUtils.Simulate.submit(form);
+      expect(onSubmit).toBeCalledWith("바보");
+    }
   });
 });

--- a/src/test/__snapshots__/Keyboard.test.tsx.snap
+++ b/src/test/__snapshots__/Keyboard.test.tsx.snap
@@ -162,7 +162,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
   >
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -194,7 +193,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -226,7 +224,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -258,7 +255,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -290,7 +286,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -322,7 +317,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -354,7 +348,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -386,7 +379,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -418,7 +410,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -450,7 +441,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -486,7 +476,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
   >
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -518,7 +507,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -550,7 +538,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -582,7 +569,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -614,7 +600,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -646,7 +631,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -678,7 +662,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -710,7 +693,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -742,7 +724,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -778,7 +759,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
   >
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -810,7 +790,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -842,7 +821,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -874,7 +852,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -906,7 +883,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -938,7 +914,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"
@@ -970,7 +945,6 @@ exports[`<Keyboard/> renders correctly 1`] = `
     </div>
     <div
       className="c2"
-      style={Object {}}
     >
       <div
         className="c3"

--- a/src/test/__snapshots__/Keyboard.test.tsx.snap
+++ b/src/test/__snapshots__/Keyboard.test.tsx.snap
@@ -147,6 +147,16 @@ exports[`<Keyboard/> renders correctly 1`] = `
 <div
   className="c0"
 >
+  <form
+    onSubmit={[Function]}
+  >
+    <input
+      autoFocus={true}
+      onChange={[Function]}
+      type="text"
+      value=""
+    />
+  </form>
   <div
     className="c1"
   >

--- a/src/test/manager.test.ts
+++ b/src/test/manager.test.ts
@@ -55,6 +55,27 @@ describe("manager", () => {
     });
   });
 
+  describe("popBubble()", () => {
+    beforeAll(() => {
+      document.body.innerHTML = `
+        <div>
+          <div id=${vocab.id}></div>
+        </div>
+      `;
+    });
+
+    afterAll(() => {
+      document.body.innerHTML = "";
+    });
+
+    it("adds in-line styling for a vanishing effect", () => {
+      manager.popBubble(vocab);
+      const bubble = document.getElementById(vocab.id);
+      expect(bubble?.style.transform).toBe("scale(0)");
+      expect(bubble?.style.transition).toBe("transform 150ms ease");
+    });
+  });
+
   describe("renderPlatform()", () => {
     it("keeps track of all platforms", () => {
       const beforeRender = manager.Test.getPlatforms();


### PR DESCRIPTION
1. Connect the keyboard and rendered bubbles via callback and invoke when submitting the form
2. Add an initial vanishing effect to the entered bubbles
3. Testing

***
Unintended regression (nothing is broken) -- cannot highlight the most recently pressed key on the on-screen keyboard because of complications with only using the `keypress` event listener to determine if a user typed a valid word

The letters/word captured with the event handler were all in English and it's not simple to determine a user's language / keyboard settings and we cannot assume just by converting over to Korean -- would lead to many inaccuracies.

This led to the addition of a `form and input`. This was an idea from the beginning, mostly for mobile devices though. This way we have access to the accurate typed Korean.

With that said, we cannot accurately determine what the last pressed Korean key this way because of how Korean is jumbled together `ㅁ ㅜ ㄴ -> 문`.